### PR TITLE
Fixes the prototype version to work with Firefox

### DIFF
--- a/generators/assignment_lists_prototype/templates/javascripts/assignment_lists_prototype.js
+++ b/generators/assignment_lists_prototype/templates/javascripts/assignment_lists_prototype.js
@@ -4,7 +4,7 @@ function AssignmentLists(srcListId, destListId, outParamName){
   this.srclist  = $(srcListId);
   this.destlist = $(destListId);
 
-  this.parentOfDestList = this.destlist.parentElement;
+  this.parentOfDestList = this.destlist.parentNode;
 
   this.repopulateListFromJSON = function(newListItems){
     this.srclist.update('');


### PR DESCRIPTION
In Firefox the parent was "undefined" and it had the side-effect to delete, among others, standard Rails hidden fields with the HTTP verb and the authentication token.

Note: this has _not_ been tested in IE but it works fine with Webkit browsers.
